### PR TITLE
I18n::InvalidLocale解決

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -63,11 +63,3 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
-  ja:
-  activerecord:
-    attributes:
-      user:
-        name: "お名前"
-        password: "パスワード"
-        password_confirmation: "パスワード確認"
-        email: "メールアドレス"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: "お名前"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        email: "メールアドレス"


### PR DESCRIPTION
# What
I18n::InvalidLocale解決しました。

# Why
http://localhost:3000/users/sign_upにアクセスできなかったため。

